### PR TITLE
set delegate cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 lib
 .env
+
+.idea

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1018,6 +1018,9 @@ yargs(hideBin(process.argv)).command(
   },
 ).argv;
 
+// e.g. yarn cli set-delegate mainnet.1 <mango-account-pk> <delegate-pk> \
+// --keypair ~/.config/solana/<mango-account-owner-keypair>.json \
+// --config src/ids.json --cluster mainnet
 yargs(hideBin(process.argv)).command(
   'set-delegate <group> <mango_account> <delegate>',
   'support setting a delegate as a signer for a mango account',


### PR DESCRIPTION
This lets a mango account owner, set a delegate. The delegate can then operate the account i.e. sign the transactions. Delegate cant withdraw funds. 

e.g.
```
yarn cli set-delegate mainnet.1 <mango-account-pk> <delegate-pk> --keypair /Users/mc/.config/solana/<mango-account-owner-keypair>.json --config src/ids.json --cluster mainnet
```


Signed-off-by: microwavedcola1 <microwavedcola@gmail.com>