### PR TITLE
Updates WalletAdapter type

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,13 +4,11 @@ import { PublicKey, Transaction } from '@solana/web3.js';
 export type Modify<T, R> = Omit<T, keyof R> & R;
 export interface WalletAdapter {
   publicKey: PublicKey;
-  autoApprove: boolean;
   connected: boolean;
   signTransaction: (transaction: Transaction) => Promise<Transaction>;
   signAllTransactions: (transaction: Transaction[]) => Promise<Transaction[]>;
   connect: () => any;
   disconnect: () => any;
-  on(event: string, fn: () => void): this;
 }
 
 export type PerpOrderType =


### PR DESCRIPTION
- Removes two deprecated fields on `WalletAdapter` - `autoApprove` and `on` - updated in https://github.com/blockworks-foundation/mango-ui-v3/pull/186