### PR TITLE
Updates types for new wallet adapter

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -8,7 +8,7 @@ import {
   MangoClient,
   ZERO_BN,
 } from '../src';
-import { Account, Commitment, Connection } from '@solana/web3.js';
+import { Keypair, Commitment, Connection } from '@solana/web3.js';
 import configFile from '../src/ids.json';
 import { Market } from '@project-serum/serum';
 
@@ -64,7 +64,7 @@ async function examplePerp() {
   }
 
   // Place order
-  const owner = new Account(readKeypair());
+  const owner = new Keypair(readKeypair());
   const mangoAccount = (
     await client.getMangoAccountsForOwner(mangoGroup, owner.publicKey)
   )[0];
@@ -157,7 +157,7 @@ async function exampleSpot() {
   }
 
   // Place order
-  const owner = new Account(readKeypair());
+  const owner = new Keypair(readKeypair());
   const mangoAccount = (
     await client.getMangoAccountsForOwner(mangoGroup, owner.publicKey)
   )[0];

--- a/examples/registerRefId.ts
+++ b/examples/registerRefId.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import os from 'os';
 import { Cluster, Config, GroupConfig, IDS, MangoClient } from '../src';
-import { Account, Commitment, Connection, PublicKey } from '@solana/web3.js';
+import { Keypair, Commitment, Connection, PublicKey } from '@solana/web3.js';
 
 async function main() {
-  const payer = new Account(
+  const payer = new Keypair(
     JSON.parse(
       fs.readFileSync(
         process.env.KEYPAIR || os.homedir() + '/.config/solana/devnet.json',

--- a/src/cli/addPerpMarket.ts
+++ b/src/cli/addPerpMarket.ts
@@ -1,4 +1,4 @@
-import { Account, Connection } from '@solana/web3.js';
+import { Keypair, Connection } from '@solana/web3.js';
 import { uiToNative } from '..';
 import { MangoClient } from '../client';
 import {
@@ -12,7 +12,7 @@ import {
 
 export default async function addPerpMarket(
   connection: Connection,
-  payer: Account,
+  payer: Keypair,
   groupConfig: GroupConfig,
   symbol: string,
   maintLeverage: number,

--- a/src/cli/addPythOracle.ts
+++ b/src/cli/addPythOracle.ts
@@ -1,4 +1,4 @@
-import { Account, Connection, PublicKey } from '@solana/web3.js';
+import { Connection, Keypair, PublicKey } from '@solana/web3.js';
 import { MangoClient } from '../client';
 import { getOracleBySymbol, GroupConfig } from '../config';
 
@@ -27,7 +27,7 @@ const PYTH_ORACLES_MAINNET = {
 
 export default async function addPythOracle(
   connection: Connection,
-  payer: Account,
+  payer: Keypair,
   groupConfig: GroupConfig,
   symbol: string,
 ): Promise<GroupConfig> {

--- a/src/cli/addSpotMarket.ts
+++ b/src/cli/addSpotMarket.ts
@@ -1,5 +1,5 @@
 import { Market } from '@project-serum/serum';
-import { Account, Connection, PublicKey } from '@solana/web3.js';
+import { Keypair, Connection, PublicKey } from '@solana/web3.js';
 import { MangoClient } from '../client';
 import {
   getOracleBySymbol,
@@ -11,7 +11,7 @@ import {
 
 export default async function addSpotMarket(
   connection: Connection,
-  payer: Account,
+  payer: Keypair,
   groupConfig: GroupConfig,
   symbol: string,
   spotMarket: PublicKey,

--- a/src/cli/addStubOracle.ts
+++ b/src/cli/addStubOracle.ts
@@ -1,10 +1,10 @@
-import { Account, Connection } from '@solana/web3.js';
+import { Keypair, Connection } from '@solana/web3.js';
 import { MangoClient } from '../client';
 import { getOracleBySymbol, GroupConfig } from '../config';
 
 export default async function addStubOracle(
   connection: Connection,
-  payer: Account,
+  payer: Keypair,
   groupConfig: GroupConfig,
   symbol: string,
 ): Promise<GroupConfig> {

--- a/src/cli/addSwitchboardOracle.ts
+++ b/src/cli/addSwitchboardOracle.ts
@@ -1,4 +1,4 @@
-import { Account, Connection, PublicKey } from '@solana/web3.js';
+import { Keypair, Connection, PublicKey } from '@solana/web3.js';
 import { MangoClient } from '../client';
 import { getOracleBySymbol, GroupConfig } from '../config';
 
@@ -15,7 +15,7 @@ const SWITCHBOARD_ORACLES_MAINNET = {
 
 export default async function addSwitchboardOracle(
   connection: Connection,
-  payer: Account,
+  payer: Keypair,
   groupConfig: GroupConfig,
   symbol: string,
 ): Promise<GroupConfig> {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,13 @@ import * as os from 'os';
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 import { Options, PositionalOptions } from 'yargs';
-import { Account, Commitment, Connection, PublicKey } from '@solana/web3.js';
+import {
+  Account,
+  Commitment,
+  Connection,
+  Keypair,
+  PublicKey,
+} from '@solana/web3.js';
 import {
   Cluster,
   Config,
@@ -88,7 +94,7 @@ function openConnection(config: Config, cluster: Cluster) {
 }
 
 function readKeypair(keypairPath: string) {
-  return new Account(JSON.parse(fs.readFileSync(keypairPath, 'utf-8')));
+  return new Keypair(JSON.parse(fs.readFileSync(keypairPath, 'utf-8')));
 }
 
 export function readConfig(configPath: string) {

--- a/src/cli/initGroup.ts
+++ b/src/cli/initGroup.ts
@@ -1,10 +1,10 @@
-import { Account, Connection, PublicKey } from '@solana/web3.js';
+import { Keypair, Connection, PublicKey } from '@solana/web3.js';
 import { MangoClient } from '../client';
 import { Cluster, GroupConfig, msrmMints } from '../config';
 
 export default async function initGroup(
   connection: Connection,
-  payer: Account,
+  payer: Keypair,
   cluster: Cluster,
   groupName: string,
   mangoProgramId: PublicKey,

--- a/src/cli/listMarket.ts
+++ b/src/cli/listMarket.ts
@@ -5,7 +5,7 @@ import {
   TokenInstructions,
 } from '@project-serum/serum';
 import {
-  Account,
+  Keypair,
   Connection,
   PublicKey,
   SystemProgram,
@@ -16,7 +16,7 @@ import { ZERO_BN } from '../utils/utils';
 
 export default async function listMarket(
   connection: Connection,
-  payer: Account,
+  payer: Keypair,
   mangoProgramId: PublicKey,
   baseMint: PublicKey,
   quoteMint: PublicKey,
@@ -26,13 +26,13 @@ export default async function listMarket(
 ): Promise<PublicKey> {
   const client = new MangoClient(connection, mangoProgramId);
 
-  const market = new Account();
-  const requestQueue = new Account();
-  const eventQueue = new Account();
-  const bids = new Account();
-  const asks = new Account();
-  const baseVault = new Account();
-  const quoteVault = new Account();
+  const market = new Keypair();
+  const requestQueue = new Keypair();
+  const eventQueue = new Keypair();
+  const bids = new Keypair();
+  const asks = new Keypair();
+  const baseVault = new Keypair();
+  const quoteVault = new Keypair();
   const feeRateBps = 0;
   const quoteDustThreshold = new BN(100);
 

--- a/src/cli/setStubOracle.ts
+++ b/src/cli/setStubOracle.ts
@@ -1,10 +1,10 @@
-import { Account, Connection } from '@solana/web3.js';
+import { Keypair, Connection } from '@solana/web3.js';
 import { MangoClient } from '../client';
 import { getOracleBySymbol, GroupConfig, OracleConfig } from '../config';
 
 export default async function setStubOracle(
   connection: Connection,
-  payer: Account,
+  payer: Keypair,
   groupConfig: GroupConfig,
   symbol: string,
   value: number,

--- a/src/client.ts
+++ b/src/client.ts
@@ -119,7 +119,7 @@ import {
 import { I80F48, ONE_I80F48, ZERO_I80F48 } from './utils/fixednum';
 import { Order } from '@project-serum/serum/lib/market';
 
-import { PerpOrderType, BlockhashTimes } from './utils/types';
+import { PerpOrderType, BlockhashTimes, Payer } from './utils/types';
 import { Adapter, adapterHasSignAllTransactions } from './utils/adapterTypes';
 import { BookSide, PerpOrder } from './book';
 import {
@@ -197,7 +197,7 @@ export class MangoClient {
 
   async sendTransactions(
     transactions: Transaction[],
-    payer: Adapter | Keypair,
+    payer: Payer,
     additionalSigners: Keypair[],
     timeout: number | null = null,
     confirmLevel: TransactionConfirmationStatus = 'confirmed',
@@ -248,7 +248,7 @@ export class MangoClient {
       transaction: Transaction;
       signers?: Array<Keypair>;
     }[];
-    payer: Adapter | Keypair;
+    payer: Payer;
   }) {
     const now = getUnixTs();
     let blockhash;
@@ -294,7 +294,7 @@ export class MangoClient {
    */
   async sendTransaction(
     transaction: Transaction,
-    payer: Adapter | Keypair,
+    payer: Payer,
     additionalSigners: Keypair[],
     timeout: number | null = 30000,
     confirmLevel: TransactionConfirmationStatus = 'processed',
@@ -629,7 +629,7 @@ export class MangoClient {
     quoteOptimalUtil: number,
     quoteOptimalRate: number,
     quoteMaxRate: number,
-    payer: Adapter | Keypair,
+    payer: Payer,
   ): Promise<PublicKey> {
     const accountInstruction = await createAccountInstruction(
       this.connection,
@@ -764,7 +764,7 @@ export class MangoClient {
    */
   async initMangoAccount(
     mangoGroup: MangoGroup,
-    owner: Adapter | Keypair,
+    owner: Payer,
   ): Promise<PublicKey> {
     const accountInstruction = await createAccountInstruction(
       this.connection,
@@ -796,7 +796,7 @@ export class MangoClient {
    */
   async createMangoAccount(
     mangoGroup: MangoGroup,
-    owner: Adapter | Keypair,
+    owner: Payer,
     accountNum: number,
     payerPk?: PublicKey,
   ): Promise<PublicKey> {
@@ -834,7 +834,7 @@ export class MangoClient {
    */
   async upgradeMangoAccountV0V1(
     mangoGroup: MangoGroup,
-    owner: Adapter | Keypair,
+    owner: Payer,
     accountNum: number,
   ): Promise<PublicKey> {
     const accountNumBN = new BN(accountNum);
@@ -893,7 +893,7 @@ export class MangoClient {
    */
   async initMangoAccountAndDeposit(
     mangoGroup: MangoGroup,
-    owner: Adapter | Keypair,
+    owner: Payer,
     rootBank: PublicKey,
     nodeBank: PublicKey,
     vault: PublicKey,
@@ -1009,7 +1009,7 @@ export class MangoClient {
    */
   async createMangoAccountAndDeposit(
     mangoGroup: MangoGroup,
-    owner: Adapter | Keypair,
+    owner: Payer,
     rootBank: PublicKey,
     nodeBank: PublicKey,
     vault: PublicKey,
@@ -1154,7 +1154,7 @@ export class MangoClient {
   async deposit(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
     rootBank: PublicKey,
     nodeBank: PublicKey,
     vault: PublicKey,
@@ -1239,7 +1239,7 @@ export class MangoClient {
   async withdraw(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
     rootBank: PublicKey,
     nodeBank: PublicKey,
     vault: PublicKey,
@@ -1339,7 +1339,7 @@ export class MangoClient {
   async withdrawAll(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
   ) {
     const transactionsAndSigners: {
       transaction: Transaction;
@@ -1470,7 +1470,7 @@ export class MangoClient {
     mangoGroup: PublicKey,
     mangoCache: PublicKey,
     rootBanks: PublicKey[],
-    payer: Adapter | Keypair,
+    payer: Payer,
   ): Promise<TransactionSignature> {
     const cacheRootBanksInstruction = makeCacheRootBankInstruction(
       this.programId,
@@ -1492,7 +1492,7 @@ export class MangoClient {
     mangoGroup: PublicKey,
     mangoCache: PublicKey,
     oracles: PublicKey[],
-    payer: Adapter | Keypair,
+    payer: Payer,
   ): Promise<TransactionSignature> {
     const cachePricesInstruction = makeCachePricesInstruction(
       this.programId,
@@ -1536,7 +1536,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     rootBank: PublicKey,
     nodeBanks: PublicKey[],
-    payer: Adapter | Keypair,
+    payer: Payer,
   ): Promise<TransactionSignature> {
     const updateRootBanksInstruction = makeUpdateRootBankInstruction(
       this.programId,
@@ -1633,7 +1633,7 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     mangoCache: PublicKey, // TODO - remove; already in MangoGroup
     perpMarket: PerpMarket,
-    owner: Adapter | Keypair,
+    owner: Payer,
 
     side: 'buy' | 'sell',
     price: number,
@@ -1721,7 +1721,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
     perpMarket: PerpMarket,
-    owner: Adapter | Keypair,
+    owner: Payer,
 
     side: 'buy' | 'sell',
     price: number,
@@ -1835,7 +1835,7 @@ export class MangoClient {
   async cancelPerpOrder(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
     perpMarket: PerpMarket,
     order: PerpOrder,
     invalidIdOk = false,
@@ -1866,7 +1866,7 @@ export class MangoClient {
     group: MangoGroup,
     perpMarkets: PerpMarket[],
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
   ): Promise<TransactionSignature[]> {
     let tx = new Transaction();
     const transactions: Transaction[] = [];
@@ -2076,7 +2076,7 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     mangoCache: PublicKey,
     spotMarket: Market,
-    owner: Adapter | Keypair,
+    owner: Payer,
 
     side: 'buy' | 'sell',
     price: number,
@@ -2261,7 +2261,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
     spotMarket: Market,
-    owner: Adapter | Keypair,
+    owner: Payer,
 
     side: 'buy' | 'sell',
     price: number,
@@ -2465,7 +2465,7 @@ export class MangoClient {
   async cancelSpotOrder(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
     spotMarket: Market,
     order: Order,
   ): Promise<TransactionSignature> {
@@ -2536,7 +2536,7 @@ export class MangoClient {
   async settleFunds(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
     spotMarket: Market,
   ): Promise<TransactionSignature> {
     const marketIndex = mangoGroup.getSpotMarketIndex(spotMarket.publicKey);
@@ -2595,7 +2595,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
     spotMarkets: Market[],
-    owner: Adapter | Keypair,
+    owner: Payer,
   ): Promise<TransactionSignature[]> {
     const transactions: Transaction[] = [];
 
@@ -2750,7 +2750,7 @@ export class MangoClient {
     perpMarket: PerpMarket,
     quoteRootBank: RootBank,
     price: I80F48, // should be the MangoCache price
-    owner: Adapter | Keypair,
+    owner: Payer,
     mangoAccounts?: MangoAccount[],
   ): Promise<TransactionSignature | null> {
     // fetch all MangoAccounts filtered for having this perp market in basket
@@ -2884,7 +2884,7 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     perpMarkets: PerpMarket[],
     quoteRootBank: RootBank,
-    owner: Adapter | Keypair,
+    owner: Payer,
     mangoAccounts?: MangoAccount[],
   ): Promise<(TransactionSignature | null)[]> {
     // fetch all MangoAccounts filtered for having this perp market in basket
@@ -2926,7 +2926,7 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     perpMarkets: PerpMarket[],
     quoteRootBank: RootBank,
-    owner: Adapter | Keypair,
+    owner: Payer,
     mangoAccounts?: MangoAccount[],
   ): Promise<(TransactionSignature | null)[]> {
     // fetch all MangoAccounts filtered for having this perp market in basket
@@ -3220,7 +3220,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     oraclePk: PublicKey,
     mngoMintPk: PublicKey,
-    admin: Adapter | Keypair,
+    admin: Payer,
     maintLeverage: number,
     initLeverage: number,
     liquidationFee: number,
@@ -3420,7 +3420,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     liqee: MangoAccount,
     perpMarket: PerpMarket,
-    payer: Adapter | Keypair,
+    payer: Payer,
     limitPerInstruction: number,
   ): Promise<TransactionSignature> {
     const transaction = new Transaction();
@@ -3692,7 +3692,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
     perpMarket: PerpMarket,
-    payer: Adapter | Keypair,
+    payer: Payer,
     mngoRootBank: PublicKey,
     mngoNodeBank: PublicKey,
     mngoVault: PublicKey,
@@ -3719,7 +3719,7 @@ export class MangoClient {
   async redeemAllMngo(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    payer: Adapter | Keypair,
+    payer: Payer,
     mngoRootBank: PublicKey,
     mngoNodeBank: PublicKey,
     mngoVault: PublicKey,
@@ -3800,7 +3800,7 @@ export class MangoClient {
   async addMangoAccountInfo(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
     info: string,
   ): Promise<TransactionSignature> {
     const instruction = makeAddMangoAccountInfoInstruction(
@@ -3820,7 +3820,7 @@ export class MangoClient {
   async depositMsrm(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
     msrmAccount: PublicKey,
     quantity: number,
   ): Promise<TransactionSignature> {
@@ -3842,7 +3842,7 @@ export class MangoClient {
   async withdrawMsrm(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
     msrmAccount: PublicKey,
     quantity: number,
   ): Promise<TransactionSignature> {
@@ -3866,7 +3866,7 @@ export class MangoClient {
   async changePerpMarketParams(
     mangoGroup: MangoGroup,
     perpMarket: PerpMarket,
-    admin: Adapter | Keypair,
+    admin: Payer,
 
     maintLeverage: number | undefined,
     initLeverage: number | undefined,
@@ -3906,7 +3906,7 @@ export class MangoClient {
   async changePerpMarketParams2(
     mangoGroup: MangoGroup,
     perpMarket: PerpMarket,
-    admin: Adapter | Keypair,
+    admin: Payer,
 
     maintLeverage: number | undefined,
     initLeverage: number | undefined,
@@ -3950,7 +3950,7 @@ export class MangoClient {
   async setGroupAdmin(
     mangoGroup: MangoGroup,
     newAdmin: PublicKey,
-    admin: Adapter | Keypair,
+    admin: Payer,
   ): Promise<TransactionSignature> {
     const instruction = makeSetGroupAdminInstruction(
       this.programId,
@@ -3972,7 +3972,7 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     mangoCache: PublicKey,
     spotMarket: Market,
-    owner: Adapter | Keypair,
+    owner: Payer,
     order: Order,
 
     side: 'buy' | 'sell',
@@ -4195,7 +4195,7 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     mangoCache: PublicKey,
     perpMarket: PerpMarket,
-    owner: Adapter | Keypair,
+    owner: Payer,
     order: PerpOrder,
 
     side: 'buy' | 'sell',
@@ -4291,7 +4291,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
     perpMarket: PerpMarket,
-    owner: Adapter | Keypair,
+    owner: Payer,
     orderType: PerpOrderType,
     side: 'buy' | 'sell',
     price: number,
@@ -4378,7 +4378,7 @@ export class MangoClient {
   async removeAdvancedOrder(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    owner: Adapter | Keypair,
+    owner: Payer,
     orderIndex: number,
   ): Promise<TransactionSignature> {
     const instruction = makeRemoveAdvancedOrderInstruction(
@@ -4400,7 +4400,7 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     mangoCache: MangoCache,
     perpMarket: PerpMarket,
-    payer: Adapter | Keypair,
+    payer: Payer,
     orderIndex: number,
   ): Promise<TransactionSignature> {
     const openOrders = mangoAccount.spotOpenOrders.filter(
@@ -4430,7 +4430,7 @@ export class MangoClient {
   async closeAdvancedOrders(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    payer: Adapter | Keypair,
+    payer: Payer,
   ): Promise<TransactionSignature> {
     const instruction = makeCloseAdvancedOrdersInstruction(
       this.programId,
@@ -4448,7 +4448,7 @@ export class MangoClient {
   async closeSpotOpenOrders(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    payer: Adapter | Keypair,
+    payer: Payer,
     marketIndex: number,
   ): Promise<TransactionSignature> {
     const instruction = makeCloseSpotOpenOrdersInstruction(
@@ -4470,7 +4470,7 @@ export class MangoClient {
   async closeMangoAccount(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    payer: Adapter | Keypair,
+    payer: Payer,
   ): Promise<TransactionSignature> {
     const instruction = makeCloseMangoAccountInstruction(
       this.programId,
@@ -4486,7 +4486,7 @@ export class MangoClient {
 
   async createDustAccount(
     mangoGroup: MangoGroup,
-    payer: Adapter | Keypair,
+    payer: Payer,
   ): Promise<TransactionSignature> {
     const [mangoAccountPk] = await PublicKey.findProgramAddress(
       [mangoGroup.publicKey.toBytes(), new Buffer('DustAccount', 'utf-8')],
@@ -4509,7 +4509,7 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     rootBank: RootBank,
     mangoCache: MangoCache,
-    payer: Adapter | Keypair,
+    payer: Payer,
   ): Promise<TransactionSignature> {
     const [dustAccountPk] = await PublicKey.findProgramAddress(
       [mangoGroup.publicKey.toBytes(), new Buffer('DustAccount', 'utf-8')],
@@ -4534,7 +4534,7 @@ export class MangoClient {
   async updateMarginBasket(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    payer: Adapter | Keypair,
+    payer: Payer,
   ) {
     const instruction = makeUpdateMarginBasketInstruction(
       this.programId,
@@ -4552,7 +4552,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
     mangoCache: MangoCache,
-    payer: Adapter | Keypair,
+    payer: Payer,
   ) {
     const transactionsAndSigners: {
       transaction: Transaction;
@@ -4626,7 +4626,7 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     mangoCache: MangoCache,
     mngoIndex: number,
-    payer: Adapter | Keypair,
+    payer: Payer,
   ): Promise<TransactionSignature[]> {
     const transactionsAndSigners: {
       transaction: Transaction;
@@ -4895,7 +4895,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
     perpMarket: PerpMarket,
-    payer: Adapter | Keypair,
+    payer: Payer,
     side: 'buy' | 'sell',
     limit: number,
   ) {
@@ -4920,7 +4920,7 @@ export class MangoClient {
   async setDelegate(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    payer: Adapter | Keypair,
+    payer: Payer,
     delegate: PublicKey,
   ) {
     const instruction = makeSetDelegateInstruction(
@@ -4941,7 +4941,7 @@ export class MangoClient {
     mangoGroup: MangoGroup,
     spotMarket: Market,
     rootBank: RootBank,
-    admin: Adapter | Keypair,
+    admin: Payer,
 
     maintLeverage: number | undefined,
     initLeverage: number | undefined,
@@ -4983,7 +4983,7 @@ export class MangoClient {
    */
   async changeReferralFeeParams(
     mangoGroup: MangoGroup,
-    admin: Adapter | Keypair,
+    admin: Payer,
     refSurcharge: number,
     refShare: number,
     refMngoRequired: number,
@@ -5005,7 +5005,7 @@ export class MangoClient {
   async setReferrerMemory(
     mangoGroup: MangoGroup,
     mangoAccount: MangoAccount,
-    payer: Adapter | Keypair, // must be also owner of mangoAccount
+    payer: Payer, // must be also owner of mangoAccount
     referrerMangoAccountPk: PublicKey,
   ): Promise<TransactionSignature> {
     // Generate the PDA pubkey
@@ -5062,7 +5062,7 @@ export class MangoClient {
   async registerReferrerId(
     mangoGroup: MangoGroup,
     referrerMangoAccount: MangoAccount,
-    payer: Adapter | Keypair, // will also owner of referrerMangoAccount
+    payer: Payer, // will also owner of referrerMangoAccount
     referrerId: string,
   ): Promise<TransactionSignature> {
     const { referrerPda, encodedReferrerId } = await this.getReferrerPda(

--- a/src/scripts/checkMarginBaskets.ts
+++ b/src/scripts/checkMarginBaskets.ts
@@ -1,8 +1,6 @@
-import { Account, Commitment, Connection } from '@solana/web3.js';
+import { Commitment, Connection } from '@solana/web3.js';
 import { MangoClient } from '../client';
 import { Cluster, Config } from '../config';
-import * as os from 'os';
-import * as fs from 'fs';
 
 const config = Config.ids();
 const cluster = (process.env.CLUSTER || 'mainnet') as Cluster;

--- a/src/scripts/crank.ts
+++ b/src/scripts/crank.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as fs from 'fs';
 import { MangoClient } from '../client';
 import {
-  Account,
+  Keypair,
   Commitment,
   Connection,
   PublicKey,
@@ -37,7 +37,7 @@ if (!groupIds) {
 }
 const mangoProgramId = groupIds.mangoProgramId;
 const mangoGroupKey = groupIds.publicKey;
-const payer = new Account(
+const payer = new Keypair(
   JSON.parse(
     process.env.KEYPAIR ||
       fs.readFileSync(os.homedir() + '/.config/solana/devnet.json', 'utf-8'),

--- a/src/scripts/dust.ts
+++ b/src/scripts/dust.ts
@@ -4,7 +4,7 @@
 import * as os from 'os';
 import * as fs from 'fs';
 import { MangoClient } from '../client';
-import { Account, Commitment, Connection, PublicKey } from '@solana/web3.js';
+import { Keypair, Commitment, Connection, PublicKey } from '@solana/web3.js';
 import configFile from '../ids.json';
 import { Cluster, Config } from '../config';
 import { QUOTE_INDEX } from '..';
@@ -20,7 +20,7 @@ if (!groupIds) {
 }
 const mangoProgramId = groupIds.mangoProgramId;
 const mangoGroupKey = groupIds.publicKey;
-const payer = new Account(
+const payer = new Keypair(
   JSON.parse(
     process.env.KEYPAIR ||
       fs.readFileSync(os.homedir() + '/.config/solana/devnet.json', 'utf-8'),

--- a/src/scripts/keeper.ts
+++ b/src/scripts/keeper.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as fs from 'fs';
 import { MangoClient } from '../client';
 import {
-  Account,
+  Keypair,
   Commitment,
   Connection,
   PublicKey,
@@ -54,7 +54,7 @@ if (!groupIds) {
 }
 const mangoProgramId = groupIds.mangoProgramId;
 const mangoGroupKey = groupIds.publicKey;
-const payer = new Account(
+const payer = new Keypair(
   JSON.parse(
     process.env.KEYPAIR ||
       fs.readFileSync(os.homedir() + '/.config/solana/blw.json', 'utf-8'),

--- a/src/scripts/mintDevnet.ts
+++ b/src/scripts/mintDevnet.ts
@@ -1,5 +1,5 @@
 import { createDevnetConnection } from '../../test/utils';
-import { Account, PublicKey } from '@solana/web3.js';
+import { Keypair, PublicKey } from '@solana/web3.js';
 import fs from 'fs';
 import os from 'os';
 import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
@@ -176,7 +176,7 @@ const connection = createDevnetConnection();
 
 const authorityFp =
   process.env.AUTHORITY || os.homedir() + '/.config/solana/devnet.json';
-const authority = new Account(
+const authority = new Keypair(
   JSON.parse(fs.readFileSync(authorityFp, 'utf-8')),
 );
 

--- a/src/scripts/mm.ts
+++ b/src/scripts/mm.ts
@@ -6,7 +6,7 @@ import {
 } from '../config';
 import configFile from '../ids.json';
 import {
-  Account,
+  Keypair,
   Commitment,
   Connection,
   PublicKey,
@@ -45,7 +45,7 @@ async function mm() {
   const mangoProgramId = groupIds.mangoProgramId;
   const mangoGroupKey = groupIds.publicKey;
 
-  const payer = new Account(
+  const payer = new Keypair(
     JSON.parse(
       fs.readFileSync(
         process.env.KEYPAIR || os.homedir() + '/.config/solana/id.json',
@@ -345,7 +345,7 @@ async function mm() {
 
 async function onExit(
   client: MangoClient,
-  payer: Account,
+  payer: Keypair,
   mangoProgramId: PublicKey,
   mangoGroup: MangoGroup,
   perpMarket: PerpMarket,

--- a/src/scripts/scratch.ts
+++ b/src/scripts/scratch.ts
@@ -1,11 +1,11 @@
 import { Cluster, Config, GroupConfig } from '../config';
-import { Account, Commitment, Connection, PublicKey } from '@solana/web3.js';
+import { Keypair, Commitment, Connection, PublicKey } from '@solana/web3.js';
 import fs from 'fs';
 import os from 'os';
 import { IDS, MangoClient, QUOTE_INDEX, RootBank } from '../index';
 
 async function main() {
-  const payer = new Account(
+  const payer = new Keypair(
     JSON.parse(
       fs.readFileSync(
         process.env.KEYPAIR || os.homedir() + '/.config/solana/id.json',

--- a/src/utils/adapterTypes.ts
+++ b/src/utils/adapterTypes.ts
@@ -1,0 +1,102 @@
+import {
+  Connection,
+  PublicKey,
+  SendOptions,
+  Transaction,
+  Signer,
+  TransactionSignature,
+} from '@solana/web3.js';
+import EventEmitter from 'eventemitter3';
+
+declare class WalletError extends Error {
+  error: any;
+  constructor(message?: string, error?: any);
+}
+
+interface SignerWalletAdapterProps {
+  signTransaction(transaction: Transaction): Promise<Transaction>;
+  signAllTransactions(transaction: Transaction[]): Promise<Transaction[]>;
+}
+
+interface SendTransactionOptions extends SendOptions {
+  signers?: Signer[];
+}
+
+interface WalletAdapterEvents {
+  connect(publicKey: PublicKey): void;
+  disconnect(): void;
+  error(error: WalletError): void;
+  readyStateChange(readyState: WalletReadyState): void;
+}
+
+interface MessageSignerWalletAdapterProps {
+  signMessage(message: Uint8Array): Promise<Uint8Array>;
+}
+
+declare type MessageSignerWalletAdapter = WalletAdapter &
+  MessageSignerWalletAdapterProps;
+
+interface WalletAdapterProps {
+  name: WalletName;
+  url: string;
+  icon: string;
+  readyState: WalletReadyState;
+  publicKey: PublicKey;
+  connecting: boolean;
+  connected: boolean;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  sendTransaction(
+    transaction: Transaction,
+    connection: Connection,
+    options?: SendTransactionOptions,
+  ): Promise<TransactionSignature>;
+}
+
+declare type WalletName = string & {
+  __brand__: 'WalletName';
+};
+
+export declare type SignerWalletAdapter = WalletAdapter &
+  SignerWalletAdapterProps;
+
+declare type WalletAdapter = WalletAdapterProps &
+  EventEmitter<WalletAdapterEvents>;
+
+export declare type Adapter =
+  | WalletAdapter
+  | SignerWalletAdapter
+  | MessageSignerWalletAdapter;
+
+interface MessageSignerWalletAdapterProps {
+  signMessage(message: Uint8Array): Promise<Uint8Array>;
+}
+
+declare enum WalletReadyState {
+  /**
+   * User-installable wallets can typically be detected by scanning for an API
+   * that they've injected into the global context. If such an API is present,
+   * we consider the wallet to have been installed.
+   */
+  Installed = 'Installed',
+  NotDetected = 'NotDetected',
+  /**
+   * Loadable wallets are always available to you. Since you can load them at
+   * any time, it's meaningless to say that they have been detected.
+   */
+  Loadable = 'Loadable',
+  /**
+   * If a wallet is not supported on a given platform (eg. server-rendering, or
+   * mobile) then it will stay in the `Unsupported` state.
+   */
+  Unsupported = 'Unsupported',
+}
+
+export const adapterHasSignAllTransactions = (
+  adapter: any,
+): adapter is SignerWalletAdapter => {
+  if ((adapter as SignerWalletAdapter).signAllTransactions) {
+    return true;
+  }
+  return false;
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,15 +1,8 @@
-import { PublicKey, Transaction } from '@solana/web3.js';
+import { Keypair } from '@solana/web3.js';
+import { Adapter } from './adapterTypes';
 
 /** @internal */
 export type Modify<T, R> = Omit<T, keyof R> & R;
-export interface WalletAdapter {
-  publicKey: PublicKey;
-  connected: boolean;
-  signTransaction: (transaction: Transaction) => Promise<Transaction>;
-  signAllTransactions: (transaction: Transaction[]) => Promise<Transaction[]>;
-  connect: () => any;
-  disconnect: () => any;
-}
 
 export type PerpOrderType =
   | 'limit'
@@ -19,3 +12,5 @@ export type PerpOrderType =
   | 'postOnlySlide';
 
 export type BlockhashTimes = { blockhash: string; timestamp: number };
+
+export type Payer = Adapter | Keypair;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,6 +4,7 @@ import {
   AccountInfo,
   Commitment,
   Connection,
+  Keypair,
   PublicKey,
   RpcResponseAndContext,
   SimulatedTransactionResponse,
@@ -262,8 +263,8 @@ export async function createAccountInstruction(
   space: number,
   owner: PublicKey,
   lamports?: number,
-): Promise<{ account: Account; instruction: TransactionInstruction }> {
-  const account = new Account();
+): Promise<{ account: Keypair; instruction: TransactionInstruction }> {
+  const account = new Keypair();
   const instruction = SystemProgram.createAccount({
     fromPubkey: payer,
     newAccountPubkey: account.publicKey,

--- a/test/TestGroup.ts
+++ b/test/TestGroup.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import {
-  Account,
+  Keypair,
   Cluster,
   Commitment,
   Connection,
@@ -133,7 +133,7 @@ export default class TestGroup {
   oraclePks: PublicKey[] = [];
   mangoGroupKey: PublicKey = zeroKey;
   client: MangoClient;
-  payer: Account;
+  payer: Keypair;
   connection: Connection;
   log: boolean;
   logger: any;
@@ -147,7 +147,7 @@ export default class TestGroup {
       this.logger = console.log;
     }
 
-    this.payer = new Account(
+    this.payer = new Keypair(
       JSON.parse(
         process.env.KEYPAIR ||
           fs.readFileSync(

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import { Cluster, Config, MangoClient, sleep } from '../src';
 import configFile from '../src/ids.json';
-import { Account, Commitment, Connection } from '@solana/web3.js';
+import { Keypair, Commitment, Connection } from '@solana/web3.js';
 
 async function testAccounts() {
   // Load all the details for mango group
@@ -18,7 +18,7 @@ async function testAccounts() {
   }
   const mangoProgramId = groupIds.mangoProgramId;
   const mangoGroupKey = groupIds.publicKey;
-  const payer = new Account(
+  const payer = new Keypair(
     JSON.parse(
       process.env.KEYPAIR ||
         fs.readFileSync(os.homedir() + '/.config/solana/devnet.json', 'utf-8'),

--- a/test/closeaccount.test.ts
+++ b/test/closeaccount.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import { Cluster, Config, QUOTE_INDEX, sleep } from '../src';
 import configFile from '../src/ids.json';
 import {
-  Account,
+  Keypair,
   Commitment,
   Connection,
   LAMPORTS_PER_SOL,
@@ -20,7 +20,7 @@ async function testCloseAccount() {
   const sleepTime = 2000;
   const config = new Config(configFile);
 
-  const payer = new Account(
+  const payer = new Keypair(
     JSON.parse(
       process.env.KEYPAIR ||
         fs.readFileSync(os.homedir() + '/.config/solana/devnet.json', 'utf-8'),
@@ -49,7 +49,11 @@ async function testCloseAccount() {
   const quoteNodeBanks = await quoteRootBank.loadNodeBanks(connection);
 
   //const accountPk = await testGroup.client.initMangoAccount(mangoGroup, payer);
-  const accountPk = await testGroup.client.createMangoAccount(mangoGroup, payer, 1);
+  const accountPk = await testGroup.client.createMangoAccount(
+    mangoGroup,
+    payer,
+    1,
+  );
   //const accountPk2 = await testGroup.client.createMangoAccount(mangoGroup, payer, 1);
   console.log('Created Account:', accountPk.toBase58());
   //console.log('Created Account:', accountPk2.toBase58());

--- a/test/reimburse.ts
+++ b/test/reimburse.ts
@@ -2,7 +2,7 @@
  * This script was used to reimburse accounts affected by Dec 4 MSOL oracle incident
  */
 
-import { Account, Commitment, Connection, PublicKey } from '@solana/web3.js';
+import { Keypair, Commitment, Connection, PublicKey } from '@solana/web3.js';
 import fs from 'fs';
 import os from 'os';
 import {
@@ -17,7 +17,7 @@ import {
 
 const config = new Config(IDS);
 
-const payer = new Account(
+const payer = new Keypair(
   JSON.parse(
     fs.readFileSync(
       process.env.KEYPAIR || os.homedir() + '/.config/solana/id.json',

--- a/test/socializedloss.test.ts
+++ b/test/socializedloss.test.ts
@@ -12,7 +12,7 @@ import {
   I80F48,
 } from '../src';
 import configFile from '../src/ids.json';
-import { Account, Commitment, Connection } from '@solana/web3.js';
+import { Keypair, Commitment, Connection } from '@solana/web3.js';
 import { Market } from '@project-serum/serum';
 import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 
@@ -29,7 +29,7 @@ async function testSocializedLoss() {
   }
   const mangoProgramId = groupIds.mangoProgramId;
   const mangoGroupKey = groupIds.publicKey;
-  const payer = new Account(
+  const payer = new Keypair(
     JSON.parse(
       process.env.KEYPAIR ||
         fs.readFileSync(os.homedir() + '/.config/solana/devnet.json', 'utf-8'),
@@ -49,171 +49,182 @@ async function testSocializedLoss() {
   }
   const quoteNodeBanks = await quoteRootBank.loadNodeBanks(connection);
 
-    const liqor = await client.initMangoAccount(mangoGroup, payer);
-    console.log('Created Liqor:', liqor.toBase58());
-    await sleep(sleepTime);
-    const liqorAccount = await client.getMangoAccount(
-      liqor,
-      mangoGroup.dexProgramId,
-    );
-    const tokenConfig = groupIds.tokens[QUOTE_INDEX];
-    const tokenInfo = mangoGroup.tokens[QUOTE_INDEX];
-    const token = new Token(
-      connection,
-      tokenInfo.mint,
-      TOKEN_PROGRAM_ID,
-      payer,
-    );
-    const wallet = await token.getOrCreateAssociatedAccountInfo(
-      payer.publicKey,
-    );
+  const liqor = await client.initMangoAccount(mangoGroup, payer);
+  console.log('Created Liqor:', liqor.toBase58());
+  await sleep(sleepTime);
+  const liqorAccount = await client.getMangoAccount(
+    liqor,
+    mangoGroup.dexProgramId,
+  );
+  const tokenConfig = groupIds.tokens[QUOTE_INDEX];
+  const tokenInfo = mangoGroup.tokens[QUOTE_INDEX];
+  const token = new Token(connection, tokenInfo.mint, TOKEN_PROGRAM_ID, payer);
+  const wallet = await token.getOrCreateAssociatedAccountInfo(payer.publicKey);
 
-    await client.deposit(
-      mangoGroup,
-      liqorAccount,
-      payer,
-      quoteRootBank.publicKey,
-      quoteNodeBanks[0].publicKey,
-      quoteNodeBanks[0].vault,
-      wallet.address,
-      1000,
-    );
+  await client.deposit(
+    mangoGroup,
+    liqorAccount,
+    payer,
+    quoteRootBank.publicKey,
+    quoteNodeBanks[0].publicKey,
+    quoteNodeBanks[0].vault,
+    wallet.address,
+    1000,
+  );
 
-   
-    await liqorAccount.reload(connection);
-    console.log('LIQOR', liqorAccount.publicKey.toBase58());
+  await liqorAccount.reload(connection);
+  console.log('LIQOR', liqorAccount.publicKey.toBase58());
 
-    const mangoAccountPk = await client.initMangoAccount(mangoGroup, payer);
-    await sleep(sleepTime);
-    let mangoAccount = await client.getMangoAccount(
-      mangoAccountPk,
-      mangoGroup.dexProgramId,
-    );
-    console.log('Created Liqee:', mangoAccountPk.toBase58());
+  const mangoAccountPk = await client.initMangoAccount(mangoGroup, payer);
+  await sleep(sleepTime);
+  let mangoAccount = await client.getMangoAccount(
+    mangoAccountPk,
+    mangoGroup.dexProgramId,
+  );
+  console.log('Created Liqee:', mangoAccountPk.toBase58());
 
-    const cache = await mangoGroup.loadCache(connection);
-    // deposit
-    await sleep(sleepTime / 2);
+  const cache = await mangoGroup.loadCache(connection);
+  // deposit
+  await sleep(sleepTime / 2);
 
-      const rayTokenConfig = groupIds.tokens[6];
-      const tokenIndex = mangoGroup.getTokenIndex(rayTokenConfig.mintKey);
-      const rootBank = throwUndefined(rootBanks[tokenIndex]);
-    const rayTokenInfo = mangoGroup.tokens[tokenIndex];
-    console.log(rayTokenConfig.symbol)
-      const rayToken = new Token(
-        connection,
-        rayTokenInfo.mint,
-        TOKEN_PROGRAM_ID,
-        payer,
-      );
-      const rayWallet = await rayToken.getOrCreateAssociatedAccountInfo(
-        payer.publicKey,
-      );
+  const rayTokenConfig = groupIds.tokens[6];
+  const tokenIndex = mangoGroup.getTokenIndex(rayTokenConfig.mintKey);
+  const rootBank = throwUndefined(rootBanks[tokenIndex]);
+  const rayTokenInfo = mangoGroup.tokens[tokenIndex];
+  console.log(rayTokenConfig.symbol);
+  const rayToken = new Token(
+    connection,
+    rayTokenInfo.mint,
+    TOKEN_PROGRAM_ID,
+    payer,
+  );
+  const rayWallet = await rayToken.getOrCreateAssociatedAccountInfo(
+    payer.publicKey,
+  );
 
-      await sleep(sleepTime / 2);
-      const banks = await rootBank.loadNodeBanks(connection);
+  await sleep(sleepTime / 2);
+  const banks = await rootBank.loadNodeBanks(connection);
 
-      await sleep(sleepTime);
-    
-    console.log('Resetting oracle');
-      await client.setStubOracle(
-        mangoGroupKey,
-        mangoGroup.oracles[5],
-        payer,
-        10,
-      );
-      console.log('Depositing');
-        await client.deposit(
-          mangoGroup,
-          mangoAccount,
-          payer,
-          rootBank.publicKey,
-          banks[0].publicKey,
-          banks[0].vault,
-          rayWallet.address,
-          10,
-        );
-        await sleep(1000);
-    await mangoAccount.reload(connection, mangoGroup.dexProgramId);
-    console.log('Liqee Value', mangoAccount.getAssetsVal(mangoGroup, cache, 'Init').toString());
-    console.log(mangoAccount.toPrettyString(groupIds, mangoGroup, cache));
-    console.log('withdrawing');
-    await client.withdraw(
+  await sleep(sleepTime);
+
+  console.log('Resetting oracle');
+  await client.setStubOracle(mangoGroupKey, mangoGroup.oracles[5], payer, 10);
+  console.log('Depositing');
+  await client.deposit(
+    mangoGroup,
+    mangoAccount,
+    payer,
+    rootBank.publicKey,
+    banks[0].publicKey,
+    banks[0].vault,
+    rayWallet.address,
+    10,
+  );
+  await sleep(1000);
+  await mangoAccount.reload(connection, mangoGroup.dexProgramId);
+  console.log(
+    'Liqee Value',
+    mangoAccount.getAssetsVal(mangoGroup, cache, 'Init').toString(),
+  );
+  console.log(mangoAccount.toPrettyString(groupIds, mangoGroup, cache));
+  console.log('withdrawing');
+  await client.withdraw(
+    mangoGroup,
+    mangoAccount,
+    payer,
+    quoteRootBank.publicKey,
+    quoteRootBank.nodeBanks[0],
+    quoteNodeBanks[0].vault,
+    10,
+    true,
+  );
+
+  await mangoAccount.reload(connection);
+  console.log(
+    'Liqee Health:',
+    mangoAccount.getHealth(mangoGroup, cache, 'Maint').toString(),
+  );
+  console.log('LIQEE', mangoAccount.publicKey.toBase58());
+
+  await client.setStubOracle(mangoGroupKey, mangoGroup.oracles[5], payer, 0.5);
+
+  rootBanks = await mangoGroup.loadRootBanks(connection);
+  let assetRootBank = rootBanks[5];
+  let liabRootBank = rootBanks[QUOTE_INDEX];
+  if (!liabRootBank || !assetRootBank) {
+    throw new Error('Root Banks not found');
+  }
+  const liabAmount = mangoAccount.getNativeBorrow(liabRootBank, QUOTE_INDEX);
+
+  await sleep(1000);
+
+  rootBanks = await mangoGroup.loadRootBanks(connection);
+  assetRootBank = rootBanks[5];
+  liabRootBank = rootBanks[QUOTE_INDEX];
+  if (!liabRootBank || !assetRootBank) {
+    throw new Error('Root Banks not found');
+  }
+
+  const preLiqQuoteDeposits = quoteRootBank.getNativeTotalDeposit();
+  console.log('PreLiq', preLiqQuoteDeposits.toString());
+
+  console.log('Liquidating');
+  await client.liquidateTokenAndToken(
+    mangoGroup,
+    mangoAccount,
+    liqorAccount,
+    assetRootBank,
+    liabRootBank,
+    payer,
+    I80F48.fromNumber(Math.abs(liabAmount.toNumber())),
+  );
+  await mangoAccount.reload(connection, mangoGroup.dexProgramId);
+  await sleep(1000);
+
+  rootBanks = await mangoGroup.loadRootBanks(connection);
+  assetRootBank = rootBanks[5];
+  liabRootBank = rootBanks[QUOTE_INDEX];
+  if (!liabRootBank || !assetRootBank) {
+    throw new Error('Root Banks not found');
+  }
+
+  const preLossQuoteDeposits = liabRootBank.getNativeTotalDeposit();
+  console.log('Pre', preLossQuoteDeposits.toString());
+
+  if (mangoAccount.isBankrupt) {
+    console.log('resolveTokenBankruptcy');
+    await client.resolveTokenBankruptcy(
       mangoGroup,
       mangoAccount,
+      liqorAccount,
+      quoteRootBank,
+      liabRootBank,
       payer,
-      quoteRootBank.publicKey,
-      quoteRootBank.nodeBanks[0],
-      quoteNodeBanks[0].vault,
-      10,
-      true,
+      I80F48.fromNumber(
+        Math.abs(
+          mangoAccount.getNativeBorrow(liabRootBank, QUOTE_INDEX).toNumber(),
+        ),
+      ),
     );
+  } else {
+    console.log('Account was not bankrupt');
+  }
+  await sleep(5000);
 
-    await mangoAccount.reload(connection);
-    console.log('Liqee Health:', mangoAccount.getHealth(mangoGroup, cache, 'Maint').toString());
-    console.log('LIQEE', mangoAccount.publicKey.toBase58());
+  rootBanks = await mangoGroup.loadRootBanks(connection);
+  assetRootBank = rootBanks[5];
+  liabRootBank = rootBanks[QUOTE_INDEX];
+  if (!liabRootBank || !assetRootBank) {
+    throw new Error('Root Banks not found');
+  }
 
-    await client.setStubOracle(
-        mangoGroupKey,
-        mangoGroup.oracles[5],
-        payer,
-        0.5,
-    );
+  const postLossQuoteDeposits = liabRootBank.getNativeTotalDeposit();
+  console.log('Post', postLossQuoteDeposits.toString());
 
-    rootBanks = await mangoGroup.loadRootBanks(connection);
-    let assetRootBank = rootBanks[5];
-    let liabRootBank = rootBanks[QUOTE_INDEX];
-    if (!liabRootBank || !assetRootBank) {
-        throw new Error('Root Banks not found');
-    }
-    const liabAmount = mangoAccount.getNativeBorrow(liabRootBank, QUOTE_INDEX);
-
-    await sleep(1000);
-
-    rootBanks = await mangoGroup.loadRootBanks(connection);
-    assetRootBank = rootBanks[5];
-    liabRootBank = rootBanks[QUOTE_INDEX];
-    if (!liabRootBank || !assetRootBank) {
-        throw new Error('Root Banks not found');
-    }
-
-    const preLiqQuoteDeposits = quoteRootBank.getNativeTotalDeposit();
-    console.log('PreLiq', preLiqQuoteDeposits.toString());
-
-    console.log('Liquidating');
-    await client.liquidateTokenAndToken(mangoGroup, mangoAccount, liqorAccount, assetRootBank, liabRootBank, payer, I80F48.fromNumber(Math.abs(liabAmount.toNumber())));
-    await mangoAccount.reload(connection, mangoGroup.dexProgramId);
-    await sleep(1000);
-
-    rootBanks = await mangoGroup.loadRootBanks(connection);
-    assetRootBank = rootBanks[5];
-    liabRootBank = rootBanks[QUOTE_INDEX];
-    if (!liabRootBank || !assetRootBank) {
-        throw new Error('Root Banks not found');
-    }
-
-    const preLossQuoteDeposits = liabRootBank.getNativeTotalDeposit();
-    console.log('Pre', preLossQuoteDeposits.toString());
-
-    if (mangoAccount.isBankrupt) {
-        console.log('resolveTokenBankruptcy');
-        await client.resolveTokenBankruptcy(mangoGroup, mangoAccount, liqorAccount, quoteRootBank, liabRootBank, payer, I80F48.fromNumber(Math.abs(mangoAccount.getNativeBorrow(liabRootBank, QUOTE_INDEX).toNumber())));
-    } else {
-        console.log('Account was not bankrupt');
-    }
-    await sleep(5000);
-    
-    rootBanks = await mangoGroup.loadRootBanks(connection);
-    assetRootBank = rootBanks[5];
-    liabRootBank = rootBanks[QUOTE_INDEX];
-    if (!liabRootBank || !assetRootBank) {
-        throw new Error('Root Banks not found');
-    }
-
-    const postLossQuoteDeposits = liabRootBank.getNativeTotalDeposit();
-    console.log('Post', postLossQuoteDeposits.toString());
-
-    console.log('Diff', preLossQuoteDeposits.sub(postLossQuoteDeposits).toString());
+  console.log(
+    'Diff',
+    preLossQuoteDeposits.sub(postLossQuoteDeposits).toString(),
+  );
 }
 
 testSocializedLoss();


### PR DESCRIPTION
- Removes references to deprecated `Account` type
- Adds new `Adapter` type which mirrors the (Solana Labs Wallet Adapter Adapter Type)[https://github.com/solana-labs/wallet-adapter/blob/f5e84bd73f1e7199f7b073d6485342558b9b6b96/packages/core/base/src/types.ts#L4] which is used in the Client
- Adds method `adapterHasSignAllTransactions` for checking whether or not the current adapter supports `signAllTransactions` which is slated to be deprecated at date TBD.