### PR TITLE
Fixes unspecific imports

### DIFF
--- a/src/MangoAccount.ts
+++ b/src/MangoAccount.ts
@@ -22,20 +22,17 @@ import BN from 'bn.js';
 import MangoGroup from './MangoGroup';
 import PerpAccount from './PerpAccount';
 import { EOL } from 'os';
+import { getPriceFromKey } from './book';
 import {
-  AdvancedOrdersLayout,
   getMarketByPublicKey,
-  getMultipleAccounts,
-  getPriceFromKey,
   getTokenByMint,
   GroupConfig,
   PerpMarketConfig,
-  PerpTriggerOrder,
-  sleep,
-  TokenConfig,
-  ZERO_BN,
   Config,
-} from '.';
+  TokenConfig,
+} from './config';
+import { getMultipleAccounts, sleep, ZERO_BN } from './utils/utils';
+import { AdvancedOrdersLayout, PerpTriggerOrder } from './layout';
 import PerpMarket from './PerpMarket';
 import { Order } from '@project-serum/serum/lib/market';
 import IDS from './ids.json';

--- a/src/MangoGroup.ts
+++ b/src/MangoGroup.ts
@@ -1,7 +1,7 @@
 import { Connection, PublicKey } from '@solana/web3.js';
 import { Big } from 'big.js';
 import BN from 'bn.js';
-import { NodeBank, NodeBankLayout } from '.';
+import { NodeBank, NodeBankLayout } from './layout';
 import { I80F48, ONE_I80F48 } from './utils/fixednum';
 import {
   MetaData,

--- a/src/PerpAccount.ts
+++ b/src/PerpAccount.ts
@@ -1,5 +1,6 @@
 import BN from 'bn.js';
-import { PerpMarketCache, PerpMarketInfo, ZERO_BN } from '.';
+import { PerpMarketInfo, PerpMarketCache } from './layout';
+import { ZERO_BN } from './utils/utils';
 import { I80F48, ZERO_I80F48 } from './utils/fixednum';
 import PerpMarket from './PerpMarket';
 import MangoAccount from './MangoAccount';

--- a/src/PerpEventQueue.ts
+++ b/src/PerpEventQueue.ts
@@ -1,5 +1,6 @@
 import BN from 'bn.js';
-import { FillEvent, LiquidateEvent, OutEvent, ZERO_BN } from '.';
+import { ZERO_BN } from './utils/utils';
+import { FillEvent, OutEvent, LiquidateEvent } from './layout';
 
 export default class PerpEventQueue {
   head!: BN;

--- a/src/PerpMarket.ts
+++ b/src/PerpMarket.ts
@@ -1,20 +1,18 @@
 import { Connection, PublicKey } from '@solana/web3.js';
 import Big from 'big.js';
 import BN from 'bn.js';
+import { clamp, nativeToUi, ONE_BN } from './utils/utils';
+import PerpEventQueue from './PerpEventQueue';
 import {
-  BookSide,
-  BookSideLayout,
-  clamp,
-  FillEvent,
-  MangoAccount,
-  MangoCache,
-  MetaData,
-  nativeToUi,
-  ONE_BN,
-  PerpEventQueue,
   PerpEventQueueLayout,
-  PerpMarketConfig,
-} from '.';
+  MangoCache,
+  BookSideLayout,
+  MetaData,
+  FillEvent,
+} from './layout';
+import { PerpMarketConfig } from './config';
+import MangoAccount from './MangoAccount';
+import { BookSide } from './book';
 import { I80F48 } from './utils/fixednum';
 import { Modify } from './utils/types';
 import { ZERO_BN } from './utils/utils';

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,9 @@ import {
   promiseUndef,
   simulateTransaction,
   sleep,
+  MangoError,
+  U64_MAX_BN,
+  TimeoutError,
   uiToNative,
   ZERO_BN,
   zeroKey,
@@ -133,14 +136,8 @@ import {
   TOKEN_PROGRAM_ID,
 } from '@solana/spl-token';
 import MangoGroup from './MangoGroup';
-import {
-  makeCreateSpotOpenOrdersInstruction,
-  MangoError,
-  ReferrerIdRecord,
-  ReferrerIdRecordLayout,
-  TimeoutError,
-  U64_MAX_BN,
-} from '.';
+import { makeCreateSpotOpenOrdersInstruction } from './instruction';
+import { ReferrerIdRecord, ReferrerIdRecordLayout } from './layout';
 
 /**
  * Get the current epoch timestamp in seconds with microsecond precision

--- a/src/instruction.ts
+++ b/src/instruction.ts
@@ -9,7 +9,9 @@ import BN from 'bn.js';
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { Order } from '@project-serum/serum/lib/market';
 import { I80F48, ZERO_I80F48 } from './utils/fixednum';
-import { PerpOrder, PerpOrderType, ZERO_BN } from '.';
+import { PerpOrder } from './book';
+import { PerpOrderType } from './utils/types';
+import { ZERO_BN } from './utils/utils';
 
 export function makeInitMangoGroupInstruction(
   programId: PublicKey,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,5 @@
 import BN from 'bn.js';
 import {
-  Account,
   AccountInfo,
   Commitment,
   Connection,


### PR DESCRIPTION
- Imports with `'.'` as the path were not being properly imported when consumed by the react native compiler. This PR sets the imports to specific files.
- This wouldn't be an issue if the library compiled into one JS file using babel, but because the app is just transpiling the TS files into mirrored JS files this is a problem. We should consider creating a minified single JS file for the client.