### PR TITLE
Added TxIx check to emptyAndCloseMangoAccount

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4847,8 +4847,10 @@ export class MangoClient {
       );
       redeemMngoTransaction.transaction.add(instruction);
     }
-    transactionsAndSigners.push(redeemMngoTransaction);
-
+    if (redeemMngoTransaction.transaction.instructions.length > 0){
+      transactionsAndSigners.push(redeemMngoTransaction);
+    }
+    
     const resolveAllDustTransaction = {
       transaction: new Transaction(),
       signers: [],


### PR DESCRIPTION
Added a check to verify that redeemMngoTransaction transaction instructions length is greater than zero. There can exist instances where the transaction is pushed to transactionsAndSigners without transaction instructions.