### PR TITLE
Adding missing field in mango group layout

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -956,6 +956,7 @@ export const MangoGroupLayout = struct([
   u16('refSurchargeCentibpsTier2'),
   u16('refShareCentibpsTier2'),
   u8('refMngoTier2Factor'),
+  seq(u8(), 3, 'padding'),
 ]);
 /** @internal */
 export const MangoAccountLayout = struct([


### PR DESCRIPTION
I was facing issue while creating mango group from client. I found that the issue came from difference in layout in mango client and mango_v3 MangoGroup structure. Padding was missing in mango client layout. So the rent was not currently calculated and account of different size was created.